### PR TITLE
Add live camera entity with fallback images and backoff

### DIFF
--- a/custom_components/vector/manifest.json
+++ b/custom_components/vector/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_push",
   "version": "0.1.0",
   "requirements": [
-    "pyddlvector @ git+https://github.com/MTrab/pyddlvector.git"
+    "pyddlvector @ git+https://github.com/MTrab/pyddlvector.git@main"
   ],
   "dhcp": [
     {


### PR DESCRIPTION
## Summary
- Add camera platform (default disabled)
- Add robot camera stream loop with latest-frame cache to reduce lag
- Show vector_unknown image when no frame and vector_sleep image when sleeping
- Add auth/backoff handling and setup ConfigEntryNotReady validation

## Testing
- ruff check
- pytest