### PR TITLE
fix: satisfy Home Assistant manifest validation

### DIFF
--- a/custom_components/vector/manifest.json
+++ b/custom_components/vector/manifest.json
@@ -10,17 +10,17 @@
   "iot_class": "local_push",
   "version": "0.1.0",
   "requirements": [
-    "pyddlvector @ git+https://github.com/MTrab/pyddlvector.git@main"
+    "pyddlvector@git+https://github.com/MTrab/pyddlvector.git@main"
   ],
   "dhcp": [
     {
-      "hostname": "Vector-*"
+      "hostname": "vector-*"
     }
   ],
   "zeroconf": [
     {
       "type": "_tcp.local.",
-      "name": "Vector-*"
+      "name": "vector-*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- make DHCP hostname lowercase (`vector-*`)
- make Zeroconf name lowercase (`vector-*`)
- remove requirement whitespace around `@` for `pyddlvector`

## Validation
- confirmed manifest diff matches hassfest error output