### PR TITLE
fix: sort manifest keys per Home Assistant requirement

### DIFF
--- a/custom_components/vector/manifest.json
+++ b/custom_components/vector/manifest.json
@@ -1,22 +1,22 @@
 {
   "domain": "vector",
   "name": "Digital Dream Labs Vector (Anki Vector)",
-  "documentation": "https://github.com/MTrab/vector",
-  "issue_tracker": "https://github.com/MTrab/vector/issues",
   "codeowners": [
     "@MTrab"
   ],
   "config_flow": true,
-  "iot_class": "local_push",
-  "version": "0.1.0",
-  "requirements": [
-    "pyddlvector@git+https://github.com/MTrab/pyddlvector.git@main"
-  ],
   "dhcp": [
     {
       "hostname": "vector-*"
     }
   ],
+  "documentation": "https://github.com/MTrab/vector",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/MTrab/vector/issues",
+  "requirements": [
+    "pyddlvector@git+https://github.com/MTrab/pyddlvector.git@main"
+  ],
+  "version": "0.1.0",
   "zeroconf": [
     {
       "type": "_tcp.local.",


### PR DESCRIPTION
## Summary
- reorder `custom_components/vector/manifest.json` keys to `domain`, `name`, then alphabetical order
- no functional changes